### PR TITLE
Do not require pecific py3 release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py3
 
 [testenv]
 deps=


### PR DESCRIPTION
This patch allows tox to run on any Py3k release found on the system.
