### PR TITLE
Allow wildcard dependencies and dependents

### DIFF
--- a/disentangler.py
+++ b/disentangler.py
@@ -51,6 +51,15 @@ class Disentangler(object):
                     deps = dependent_deps + [node_id]
                     self._tree[dependent_id][self.FORWARD_KEY] = deps
 
+    def _get_forward_deps(self, node_id):
+        deps = self._tree[node_id].get(self.FORWARD_KEY, [])
+        if deps == '*':
+            deps = [i for i, n in self._tree.items()
+                    if n.get(self.FORWARD_KEY) != '*']
+            self._tree[node_id][self.FORWARD_KEY] = deps
+            return deps
+        return deps
+
     def _get_ordered_nodes(self, met=None, unmet=None):
         """ Return nodes IDs oredered to satisfy dependencies """
         if unmet is None:
@@ -66,7 +75,7 @@ class Disentangler(object):
         requested = []    # Depds which will be requested but not met
 
         for node_id in unmet:
-            deps = self._tree[node_id].get(self.FORWARD_KEY, [])
+            deps = self._get_forward_deps(node_id)
             # Filter out deps that are already met
             deps = [d for d in deps if d not in met]
             if not deps:

--- a/disentangler.py
+++ b/disentangler.py
@@ -47,63 +47,53 @@ class Disentangler(object):
                     deps = dependent_deps + [node_id]
                     self._tree[dependent_id][self.FORWARD_KEY] = deps
 
-    def _collect_dependencies(self, node_id, collected=None):
-        """Recursively assemble the list of dependencies for the specified
-        node, including the node itself at the end.
+    def _get_ordered_nodes(self, met=None, unmet=None):
+        """ Return nodes IDs oredered to satisfy dependencies """
+        if unmet is None:
+            # This is our first run, so initialize the unmet dependecies to
+            # complete list of all nodes in the tree.
+            unmet = list(self._tree.keys())
+        if not unmet:
+            # There are no more unmet dependencies, so we are free to return
+            return met
 
-        :param node_id:   unique identifier of node which dependency list is
-                          being assembled
-        :param collected: param used only in recursive calls to collect all
-                          dependencies of ``node_id`` down to the root
+        met = met or []
+        still_unmet = []  # Deps that will still have unmet deps after the run
+        requested = []    # Depds which will be requested but not met
 
-        For a sample tree:
+        for node_id in unmet:
+            deps = self._tree[node_id].get(self.FORWARD_KEY, [])
+            if not deps or all(d in met for d in deps):
+                # This node either has no dependencies or all of its
+                # dpeendencies were met, so we can add it to the list of nodes
+                # with met dependencies.
+                met.append(node_id)
+                continue
+            if any(d not in unmet for d in deps):
+                # This node still has at least unmet dependency, but that
+                # dependecy is not even in the list of remaining nodes. This
+                # means we can never resolve this node's dependencies.
+                raise self.UnresolvableDependency(node_id)
+            # Dependencies are not met yet, so we are adding the node to the
+            # remaining nodes bucket.
+            still_unmet.append(node_id)
+            # Let's record the dependencies we have asked for
+            requested.extend([d for d in deps if d not in met])
 
-        A -> [B, E]
-        B -> [D]
-        C -> []
-        D -> [E]
-        E -> []
-
-        Finding the dependencies of A would return:
-
-        [E, D, B, A]
-        """
-        if collected is None:
-            # to protect against circular dependencies towards the target node
-            # itself too, it must be added to the list initially
-            collected = collections.deque([node_id])
-        # collect dependencies of the node recursively
-        try:
-            node = self._tree[node_id]
-        except KeyError:
-            raise self.UnresolvableDependency(node_id)
-        else:
-            for dep_id in node.get(self.FORWARD_KEY, []):
-                if dep_id in collected:
-                    # one of the ancestor nodes already specified this node as
-                    # a dependency, and it turned out that this node has a
-                    # reference towards the ancestor node as well, which is a
-                    # circular dependency
-                    raise self.CircularDependency(node_id, dep_id)
-                # dependencies are prepended to the list, such that when
-                # iterating over the result, dependencies are ordered from
-                # lowest to highest, towards the target node
-                collected.appendleft(dep_id)
-                # collect child dependencies, prepending children the same way
-                self._collect_dependencies(dep_id, collected=collected)
-            return collected
+        if requested and set(requested) == set(still_unmet):
+            # If the unique node IDs that we asked for matches the unique node
+            # IDs that still have unmet dependencies, we are probably looking
+            # at circular dependency issue.
+            raise self.CircularDependency(requested)
+        return self._get_ordered_nodes(met, still_unmet)
 
     def _order_nodes(self):
-        """Build a new dependency tree ordered according to the forward
-        dependency specifications and replace the unordered tree with it."""
-        ordered_tree = collections.OrderedDict()
-        for node_id in self._tree:
-            # ``node_id`` will be included in the result set returned by
-            # ``_collect_dependencies``
-            for dep_id in self._collect_dependencies(node_id):
-                if dep_id not in ordered_tree:
-                    ordered_tree[dep_id] = self._tree[dep_id]
-        self._tree = ordered_tree
+        """ Order the nodes according to forward dependency relationships, and
+        update the tree """
+        new_tree = collections.OrderedDict()
+        for node_id in self._get_ordered_nodes():
+            new_tree[node_id] = self._tree[node_id]
+        self._tree = new_tree
 
     def solve(self):
         """Disentangle the graph by ordering nodes according to the specified

--- a/disentangler.py
+++ b/disentangler.py
@@ -63,7 +63,9 @@ class Disentangler(object):
 
         for node_id in unmet:
             deps = self._tree[node_id].get(self.FORWARD_KEY, [])
-            if not deps or all(d in met for d in deps):
+            # Filter out deps that are already met
+            deps = [d for d in deps if d not in met]
+            if not deps:
                 # This node either has no dependencies or all of its
                 # dpeendencies were met, so we can add it to the list of nodes
                 # with met dependencies.

--- a/disentangler.py
+++ b/disentangler.py
@@ -37,7 +37,12 @@ class Disentangler(object):
         """Turns reverse dependencies into forward dependencies over the whole
         tree."""
         for (node_id, node) in self._tree.items():
+            if node.get(self.REVERSE_KEY) == '*':
+                # Special case where some node is required by all
+                node[self.REVERSE_KEY] = [i for i in self._tree
+                                          if i != node_id]
             for dependent_id in node.pop(self.REVERSE_KEY, []):
+                print(node_id, dependent_id)
                 try:
                     dependent = self._tree[dependent_id]
                 except KeyError:

--- a/disentangler.py
+++ b/disentangler.py
@@ -39,10 +39,9 @@ class Disentangler(object):
         for (node_id, node) in self._tree.items():
             if node.get(self.REVERSE_KEY) == '*':
                 # Special case where some node is required by all
-                node[self.REVERSE_KEY] = [i for i in self._tree
-                                          if i != node_id]
+                node[self.REVERSE_KEY] = [i for i, n in self._tree.items()
+                                          if n.get(self.REVERSE_KEY) != '*']
             for dependent_id in node.pop(self.REVERSE_KEY, []):
-                print(node_id, dependent_id)
                 try:
                     dependent = self._tree[dependent_id]
                 except KeyError:

--- a/test_disentangler.py
+++ b/test_disentangler.py
@@ -99,3 +99,23 @@ def test_required_by_all_multiple():
     inst = mod.Disentangler(dep_tree)
     ret = inst.solve()
     assert list(ret) == ['c', 'b', 'a']
+
+
+def test_depends_on_all():
+    dep_tree = mod.collections.OrderedDict()
+    dep_tree['a'] = {'depends_on': '*'}
+    dep_tree['b'] = {}
+    dep_tree['c'] = {}
+    inst = mod.Disentangler(dep_tree)
+    ret = inst.solve()
+    assert list(ret) == ['b', 'c', 'a']
+
+
+def test_depends_on_all_multiple():
+    dep_tree = mod.collections.OrderedDict()
+    dep_tree['a'] = {'depends_on': '*'}
+    dep_tree['b'] = {'depends_on': '*'}
+    dep_tree['c'] = {}
+    inst = mod.Disentangler(dep_tree)
+    ret = inst.solve()
+    assert list(ret) == ['c', 'a', 'b']

--- a/test_disentangler.py
+++ b/test_disentangler.py
@@ -59,3 +59,13 @@ def test__order_nodes_missing_dependency():
     inst = mod.Disentangler(dep_tree)
     with pytest.raises(inst.UnresolvableDependency):
         inst._order_nodes()
+
+
+def test__required_by_all():
+    dep_tree = mod.collections.OrderedDict()
+    dep_tree['a'] = {}
+    dep_tree['b'] = {}
+    dep_tree['c'] = {'required_by': '*'}
+    inst = mod.Disentangler(dep_tree)
+    ret = inst.solve()
+    assert list(ret) == ['c', 'a', 'b']

--- a/test_disentangler.py
+++ b/test_disentangler.py
@@ -51,6 +51,16 @@ def test__order_nodes_circular_dependency():
         inst._order_nodes()
 
 
+def test__order_nodes_overlapping_dependencies():
+    dep_tree = mod.collections.OrderedDict()
+    dep_tree['a'] = {'depends_on': ['c']}
+    dep_tree['b'] = {'depends_on': ['a', 'c']}
+    dep_tree['c'] = {}
+    inst = mod.Disentangler(dep_tree)
+    inst._order_nodes()
+    assert list(inst._tree) == ['c', 'a', 'b']
+
+
 def test__order_nodes_missing_dependency():
     dep_tree = mod.collections.OrderedDict()
     dep_tree['a'] = {'depends_on': ['b']}

--- a/test_disentangler.py
+++ b/test_disentangler.py
@@ -98,4 +98,4 @@ def test_required_by_all_multiple():
     dep_tree['c'] = {'required_by': '*'}
     inst = mod.Disentangler(dep_tree)
     ret = inst.solve()
-    assert list(ret) == ['b', 'c', 'a']
+    assert list(ret) == ['c', 'b', 'a']

--- a/test_disentangler.py
+++ b/test_disentangler.py
@@ -61,6 +61,16 @@ def test__order_nodes_overlapping_dependencies():
     assert list(inst._tree) == ['c', 'a', 'b']
 
 
+def test__order_nodes_multiple_deps_when_one_is_met_already():
+    dep_tree = mod.collections.OrderedDict()
+    dep_tree['a'] = {'depends_on': ['b', 'c']}
+    dep_tree['b'] = {'depends_on': ['c']}
+    dep_tree['c'] = {}
+    inst = mod.Disentangler(dep_tree)
+    inst._order_nodes()
+    assert list(inst._tree) == ['c', 'b', 'a']
+
+
 def test__order_nodes_missing_dependency():
     dep_tree = mod.collections.OrderedDict()
     dep_tree['a'] = {'depends_on': ['b']}

--- a/test_disentangler.py
+++ b/test_disentangler.py
@@ -69,3 +69,13 @@ def test__required_by_all():
     inst = mod.Disentangler(dep_tree)
     ret = inst.solve()
     assert list(ret) == ['c', 'a', 'b']
+
+
+def test_required_by_all_multiple():
+    dep_tree = mod.collections.OrderedDict()
+    dep_tree['a'] = {}
+    dep_tree['b'] = {'required_by': '*'}
+    dep_tree['c'] = {'required_by': '*'}
+    inst = mod.Disentangler(dep_tree)
+    ret = inst.solve()
+    assert list(ret) == ['b', 'c', 'a']


### PR DESCRIPTION
This patch set allows the use of `*` character in place of lists for both `depends_on` and `required_by` keys, which is treated as 'all other nodes'. This include multiple nodes that use the same wildcard.

I'm not 100% satisfied by the resulting ordering, but it probably will not matter in real-life usage.

Please note that this PR... erm... _depends on_ #2. :)
